### PR TITLE
fix: replace react-gravatar to silence React 19 script-tag warning

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -25,6 +25,11 @@ const nextConfig = {
         hostname: "t1.gstatic.com",
         pathname: "/**",
       },
+      {
+        protocol: "https",
+        hostname: "www.gravatar.com",
+        pathname: "/avatar/**",
+      },
     ],
   },
   reactStrictMode: true,

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "react-day-picker": "^9.14.0",
     "react-dom": "19.2.5",
     "react-dropzone": "^15.0.0",
-    "react-gravatar": "^2.6.3",
     "react-hook-form": "^7.72.1",
     "react-redux": "^9.2.0",
     "react-use-cookie": "^1.6.1",
@@ -58,7 +57,6 @@
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.11",
     "@tailwindcss/postcss": "^4.2.2",
-    "@types/react-gravatar": "^2.6.14",
     "eslint": "10.2.0",
     "eslint-config-next": "16.2.3",
     "eslint-config-prettier": "^10.1.8",

--- a/src/app/(protected)/(dashboard)/page.tsx
+++ b/src/app/(protected)/(dashboard)/page.tsx
@@ -5,7 +5,7 @@ import ClearCache from "@/helpers/clear-cache";
 import { useAppSelector } from "@/redux/hook";
 import { useSession } from "next-auth/react";
 import { useEffect, useState } from "react";
-import Gravatar from "react-gravatar";
+import Gravatar from "@/components/gravatar";
 import PendingTasks from "./_components/pending-tasks";
 import UpcomingEvents from "./_components/upcoming-events";
 import UpcomingHolidays from "./_components/upcoming-holidays";

--- a/src/layouts/components/avatar.tsx
+++ b/src/layouts/components/avatar.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@/lib/shadcn";
 import Image from "next/image";
 import { ComponentProps } from "react";
-import Gravatar from "react-gravatar";
+import Gravatar from "@/components/gravatar";
 
 type ImageProps = Omit<ComponentProps<typeof Image>, "src">;
 

--- a/src/layouts/components/gravatar.tsx
+++ b/src/layouts/components/gravatar.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import Image from "next/image";
+import { CSSProperties, useEffect, useState } from "react";
+
+type GravatarProps = {
+  email?: string | null;
+  size?: number;
+  default?: string;
+  className?: string;
+  style?: CSSProperties;
+  alt?: string;
+};
+
+async function sha256(input: string): Promise<string> {
+  const buf = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(input)
+  );
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export default function Gravatar({
+  email,
+  size = 80,
+  default: fallback = "mp",
+  className,
+  style,
+  alt,
+}: GravatarProps) {
+  const [hash, setHash] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!email) {
+      setHash(null);
+      return;
+    }
+    sha256(email.trim().toLowerCase())
+      .then((h) => {
+        if (!cancelled) setHash(h);
+      })
+      .catch(() => {
+        if (!cancelled) setHash(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [email]);
+
+  if (!email || !hash) return null;
+
+  const src = `https://www.gravatar.com/avatar/${hash}?s=${size * 2}&d=${encodeURIComponent(fallback)}`;
+
+  return (
+    <Image
+      src={src}
+      alt={alt || email}
+      width={size}
+      height={size}
+      className={className}
+      style={style}
+      unoptimized
+    />
+  );
+}

--- a/src/layouts/components/user-info.tsx
+++ b/src/layouts/components/user-info.tsx
@@ -1,7 +1,7 @@
 import { TEmployee } from "@/redux/features/employeeApiSlice/employeeType";
 import Link from "next/link";
 import { JSX } from "react";
-import Gravatar from "react-gravatar";
+import Gravatar from "@/components/gravatar";
 
 const UserInfo = ({
   user,

--- a/src/layouts/partials/sidebar.tsx
+++ b/src/layouts/partials/sidebar.tsx
@@ -13,7 +13,7 @@ import { LogOut } from "lucide-react";
 import { signOut, useSession } from "next-auth/react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import Gravatar from "react-gravatar";
+import Gravatar from "@/components/gravatar";
 import ConfirmationPopup from "../components/confirmation-popup";
 
 const Sidebar = ({ onClose }: { onClose?: () => void }) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1170,26 +1170,19 @@
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-19.2.3.tgz#c1e305d15a52a3e508d54dca770d202cb63abf2c"
   integrity sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==
 
-"@types/react-gravatar@^2.6.14":
-  version "2.6.14"
-  resolved "https://registry.yarnpkg.com/@types/react-gravatar/-/react-gravatar-2.6.14.tgz#2196ef241c1d9a514ec0cf17e0ea395250334dae"
-  integrity sha512-esbOXcvdGEJAsu1X8yHmArQ28Jo1gUmRZNVyA8MlEn7Z1mjj+9daHKiRoDQk61Y0kqbFGl75C4DOfUhb9uk5Tw==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react@*", "@types/react@19.2.2":
-  version "19.2.2"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.2.2.tgz#ba123a75d4c2a51158697160a4ea2ff70aa6bf36"
-  integrity sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==
-  dependencies:
-    csstype "^3.0.2"
-
 "@types/react@19.2.14":
   version "19.2.14"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-19.2.14.tgz#39604929b5e3957e3a6fa0001dafb17c7af70bad"
   integrity sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==
   dependencies:
     csstype "^3.2.2"
+
+"@types/react@19.2.2":
+  version "19.2.2"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.2.2.tgz#ba123a75d4c2a51158697160a4ea2ff70aa6bf36"
+  integrity sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==
+  dependencies:
+    csstype "^3.0.2"
 
 "@types/use-sync-external-store@^0.0.6":
   version "0.0.6"
@@ -1664,11 +1657,6 @@ cfb@~1.2.1:
     adler-32 "~1.3.0"
     crc-32 "~1.2.0"
 
-charenc@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
-  integrity sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==
-
 class-variance-authority@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/class-variance-authority/-/class-variance-authority-0.7.1.tgz#4008a798a0e4553a781a57ac5177c9fb5d043787"
@@ -1731,11 +1719,6 @@ cross-spawn@^7.0.6:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
-
-crypt@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
-  integrity sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==
 
 csstype@^3.0.2:
   version "3.1.3"
@@ -2596,11 +2579,6 @@ is-boolean-object@^1.2.1:
     call-bound "^1.0.3"
     has-tostringtag "^1.0.2"
 
-is-buffer@~1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
-  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
-
 is-bun-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-bun-module/-/is-bun-module-2.0.0.tgz#4d7859a87c0fcac950c95e666730e745eae8bddd"
@@ -2699,11 +2677,6 @@ is-regex@^1.2.1:
     gopd "^1.2.0"
     has-tostringtag "^1.0.2"
     hasown "^2.0.2"
-
-is-retina@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/is-retina/-/is-retina-1.0.3.tgz#d7401b286bea2ae37f62477588de504d0b8647e3"
-  integrity sha512-/tCmbIETZwCd8uHWO+GvbRa7jxwHFHdfetHfiwoP0aN9UDf3prUJMtKn7iBFYipYhqY1bSTjur8hC/Dakt8eyw==
 
 is-set@^2.0.3:
   version "2.0.3"
@@ -2989,15 +2962,6 @@ math-intrinsics@^1.1.0:
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
 
-md5@^2.1.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f"
-  integrity sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==
-  dependencies:
-    charenc "0.0.2"
-    crypt "0.0.2"
-    is-buffer "~1.1.6"
-
 merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
@@ -3113,7 +3077,7 @@ oauth4webapi@^3.3.0:
   resolved "https://registry.yarnpkg.com/oauth4webapi/-/oauth4webapi-3.8.2.tgz#500d1979038c14656f3f24ff1eb501ff3993115b"
   integrity sha512-FzZZ+bht5X0FKe7Mwz3DAVAmlH1BV5blSak/lHMBKz0/EBMhX6B10GlQYI51+oRp8ObJaX0g6pXrAxZh5s8rjw==
 
-object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -3306,14 +3270,6 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
-query-string@^4.2.2:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
-  integrity sha512-O2XLNDBIg1DnTOa+2XrIwSiXEV8h2KImXUnjhhn2+UsvZ+Es2uyd5CCRTNQlDGbzUQOW3aYCBx9rVA6dzsiY7Q==
-  dependencies:
-    object-assign "^4.1.0"
-    strict-uri-encode "^1.0.0"
-
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
@@ -3344,15 +3300,6 @@ react-dropzone@^15.0.0:
     attr-accept "^2.2.4"
     file-selector "^2.1.0"
     prop-types "^15.8.1"
-
-react-gravatar@^2.6.3:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/react-gravatar/-/react-gravatar-2.6.3.tgz#5407eb6ac87e830e2a34deb760d2a4c404eb1dac"
-  integrity sha512-yITonigS2LmG7Fw0gWfZfcVwy1mpiBHNVmoFyetitQjXu7JCYoE6jtub0GIfq+ydpnQSYyJT3kwpX6zj1wXR4w==
-  dependencies:
-    is-retina "^1.0.3"
-    md5 "^2.1.0"
-    query-string "^4.2.2"
 
 react-hook-form@^7.72.1:
   version "7.72.1"
@@ -3679,11 +3626,6 @@ stop-iteration-iterator@^1.1.0:
   dependencies:
     es-errors "^1.3.0"
     internal-slot "^1.1.0"
-
-strict-uri-encode@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
-  integrity sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==
 
 string.prototype.includes@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
## Summary

`react-gravatar` (unmaintained since 2018) renders a placeholder `<script>` element when no `email`/`md5` prop is provided. With Next.js 16 + React 19 this triggers a console warning on every dashboard mount:

> Encountered a script tag while rendering React component. Scripts inside React components are never executed when rendering on the client.

The same component also logs `Gravatar image can not be fetched. Either the "email" or "md5" prop must be specified.` repeatedly when the session email is briefly undefined during mount.

This PR replaces `react-gravatar` with a small in-tree component at [src/layouts/components/gravatar.tsx](https://github.com/zeon-studio/open-hr/blob/main/src/layouts/components/gravatar.tsx) that:

- Returns `null` when `email` is falsy (no warning, no placeholder)
- Hashes email with SHA-256 via `crypto.subtle` (Gravatar accepts SHA-256 since 2023, so no `md5` dependency needed)
- Uses `next/image` with `gravatar.com` added to `next.config.js` `remotePatterns`

Drops the `react-gravatar` and `@types/react-gravatar` dependencies.

## Test plan

- [x] Dashboard, sidebar, user-info, and avatar components still render Gravatars
- [x] Browser console clean — no script-tag or "email/md5 must be specified" warnings on `/` after login
- [x] `yarn install` succeeds with the trimmed dependencies
- [x] `next dev` (Turbopack) compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)