### PR TITLE
fix: guard employee-job transformResponse against null result

### DIFF
--- a/src/redux/features/employeeJobApiSlice/employeeJobSlice.ts
+++ b/src/redux/features/employeeJobApiSlice/employeeJobSlice.ts
@@ -23,18 +23,22 @@ export const employeeJobApi = employeeJobApiWithTag.injectEndpoints({
         method: "GET",
       }),
       transformResponse: (response: TEmployeeJobState<TEmployeeJob>) => {
-        response.result.promotions = response.result.promotions.sort((a, b) => {
-          return (
-            new Date(b.promotion_date).getTime() -
-            new Date(a.promotion_date).getTime()
-          );
-        });
+        if (!response.result) return response;
 
-        response.result.prev_jobs = response.result.prev_jobs.sort((a, b) => {
-          return (
-            new Date(b.end_date).getTime() - new Date(a.end_date).getTime()
+        if (response.result.promotions) {
+          response.result.promotions = response.result.promotions.sort(
+            (a, b) =>
+              new Date(b.promotion_date).getTime() -
+              new Date(a.promotion_date).getTime()
           );
-        });
+        }
+
+        if (response.result.prev_jobs) {
+          response.result.prev_jobs = response.result.prev_jobs.sort(
+            (a, b) =>
+              new Date(b.end_date).getTime() - new Date(a.end_date).getTime()
+          );
+        }
         return response;
       },
       providesTags: ["employee-jobs"],


### PR DESCRIPTION
## Summary

`GET /employee-job/:id` returns `{ result: null }` when no `employee_job` record exists yet for the given employee — for example immediately after adding a new member, before any job entry has been created.

The frontend `transformResponse` in [src/redux/features/employeeJobApiSlice/employeeJobSlice.ts](https://github.com/zeon-studio/open-hr/blob/main/src/redux/features/employeeJobApiSlice/employeeJobSlice.ts) assumes `response.result.promotions` and `response.result.prev_jobs` are always arrays and crashes on the null:

> TypeError: Cannot read properties of null (reading 'promotions')

This blocks the add-member flow.

This PR guards `transformResponse` with early-return when `result` is null and per-field checks for `promotions` and `prev_jobs`, so the empty-state response passes through unchanged.

## Test plan

- [x] Add a new member from the UI — no crash; the form/follow-up screens load
- [x] Existing employees with populated promotions/prev_jobs still get sorted correctly
- [x] Type signature unchanged (no API contract change required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)