### PR TITLE
fix: guard employee-info localStorage access during SSR

### DIFF
--- a/src/lib/employee-info.ts
+++ b/src/lib/employee-info.ts
@@ -10,6 +10,11 @@ const getEmployeesData = () => {
     };
   };
 
+  // localStorage is unavailable during SSR; fall back to the in-memory store.
+  if (typeof window === "undefined") {
+    return employees?.data?.result ?? [];
+  }
+
   const storedData = localStorage.getItem("local-employees-basics");
   if (employees?.data?.result) {
     localStorage.setItem(


### PR DESCRIPTION
## Summary

`getEmployeesData()` in [src/lib/employee-info.ts](https://github.com/zeon-studio/open-hr/blob/main/src/lib/employee-info.ts) reads and writes `localStorage` unconditionally:

```ts
const storedData = localStorage.getItem("local-employees-basics");
```

But the function is reached during the SSR pass via call sites like `employeeInfoById` (used in `user-info.tsx`, `tool-preview.tsx`, `payroll-page.tsx`, `leave-request-page.tsx`, etc.). On the server `localStorage` is undefined, producing:

> TypeError: localStorage.getItem is not a function

Next.js then falls back to client rendering with a "Recoverable Error" overlay.

This PR adds a `typeof window === "undefined"` guard at the top of `getEmployeesData`. On the server we return the in-memory Redux store result (or an empty array) and skip persistence. Client behavior is unchanged.

## Test plan

- [x] No SSR error overlay when navigating across protected pages
- [x] Employee names still resolve correctly on the client (cache hit + fallback both still work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)