### PR TITLE
feat: separate archived employees onto /employees-archived

### DIFF
--- a/src/app/(protected)/employees-archived/page.tsx
+++ b/src/app/(protected)/employees-archived/page.tsx
@@ -2,12 +2,10 @@
 
 import Pagination from "@/components/pagination";
 import SearchBox from "@/components/search-box";
-import { useDialog } from "@/hooks/useDialog";
 import useLocalCacheHook from "@/hooks/useLocalCacheHook";
 import { useGetEmployeesQuery } from "@/redux/features/employeeApiSlice/employeeSlice";
 import { useAppSelector } from "@/redux/hook";
 import { Button } from "@/ui/button";
-import { Dialog, DialogTrigger } from "@/ui/dialog";
 import {
   Table,
   TableBody,
@@ -19,63 +17,39 @@ import {
 import { useSession } from "next-auth/react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import EmployeeInsert from "./_components/employee-insert";
-import EmployeePage from "./_components/employee-page";
+import EmployeePage from "../employees/_components/employee-page";
 
-export default function Employees() {
+export default function ArchivedEmployees() {
   const { data: session } = useSession();
   const searchParams = useSearchParams();
   const { limit } = useAppSelector((state) => state.filter);
   const page = searchParams?.get("page");
   const search = searchParams?.get("search");
 
-  // get current (non-archived) employees from cache or api
   const { data } = useGetEmployeesQuery({
     page: page ? Number(page) : 1,
     limit: limit,
     search: search ? search : "",
-    status: "active,pending",
-  });
-
-  // probe for any archived employees so we can conditionally show the button
-  const { data: archivedProbe } = useGetEmployeesQuery({
-    page: 1,
-    limit: 1,
-    search: "",
     status: "archived",
   });
-  const hasArchived = (archivedProbe?.meta?.total ?? 0) > 0;
 
   const { result: employees, meta } = data || {};
   const { localData } = useLocalCacheHook(
     {
       data: employees!,
     },
-    "local-employees"
+    "local-employees-archived"
   );
-  const { isDialogOpen, onDialogChange } = useDialog();
 
   return (
     <section className="p-6">
       <div className="flex justify-between items-center mb-4">
-        <h2 className="text-h4 hidden sm:block mr-2">Employees</h2>
+        <h2 className="text-h4 hidden sm:block mr-2">Archived Employees</h2>
         <SearchBox />
-        <div className="ml-auto flex gap-2">
-          {hasArchived && (
-            <Button asChild variant="outline">
-              <Link href="/employees-archived">Archived Employee</Link>
-            </Button>
-          )}
-          <Dialog
-            modal={true}
-            open={isDialogOpen}
-            onOpenChange={onDialogChange}
-          >
-            <DialogTrigger asChild>
-              <Button>Add Employee</Button>
-            </DialogTrigger>
-            <EmployeeInsert onDialogChange={onDialogChange} />
-          </Dialog>
+        <div className="ml-auto">
+          <Button asChild variant="outline">
+            <Link href="/employees">Back to Employees</Link>
+          </Button>
         </div>
       </div>
 
@@ -97,8 +71,8 @@ export default function Employees() {
           {!employees?.length && (
             <TableRow>
               <TableCell colSpan={session?.user?.role === "admin" ? 6 : 5}>
-                <div className="loader">
-                  <div className="loader-line" />
+                <div className="text-center py-8 text-muted-foreground text-sm">
+                  No archived employees.
                 </div>
               </TableCell>
             </TableRow>

--- a/src/redux/features/employeeApiSlice/employeeSlice.ts
+++ b/src/redux/features/employeeApiSlice/employeeSlice.ts
@@ -9,10 +9,18 @@ const employeeApiWithTag = apiSlice.enhanceEndpoints({
 export const employeeApi = employeeApiWithTag.injectEndpoints({
   endpoints: (builder) => ({
     getEmployees: builder.query<TEmployeeState, TPagination>({
-      query: ({ page, limit, search }) => ({
-        url: `/employee?page=${page}&limit=${limit}&search=${search}`,
-        method: "GET",
-      }),
+      query: ({ page, limit, search, status }) => {
+        const params = new URLSearchParams({
+          page: String(page),
+          limit: String(limit),
+          search: search ?? "",
+        });
+        if (status) params.set("status", status);
+        return {
+          url: `/employee?${params.toString()}`,
+          method: "GET",
+        };
+      },
       providesTags: ["employees"],
       keepUnusedDataFor: 30 * 60,
     }),

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -4,6 +4,7 @@ export type TPagination = {
   search?: string;
   year?: string;
   employee_id?: string;
+  status?: string;
 };
 
 export type TError = {


### PR DESCRIPTION
## Summary

The main employees list previously showed every employee — including ones whose status is `archived` — as a single table with a coloured badge. Archived people who no longer work at the company aren't part of day-to-day operations, so mixing them into the same view added noise.

This PR splits the archived employees onto their own page.

**Changes**

- `/employees` now requests `status=active,pending` so archived rows disappear from the default view.
- New `/employees-archived` page reuses the same table layout and pagination, but requests `status=archived`.
- A new **"Archived Employee"** button is added before **"Add Employee"** on `/employees` — but only renders when at least one archived employee exists (probed via a tiny `page=1&limit=1&status=archived` query).
- The archived page has a "Back to Employees" link.
- `getEmployeesQuery` and `TPagination` now accept an optional `status` string, built into the URL via `URLSearchParams` (also fixes the previous habit of literally interpolating the search string into the URL without encoding).

## Backend dependency

This relies on the `/employee?status=...` filter working when the value is an array. That filter is broken on `main` and is fixed in [zeon-studio/open-hr-backend#4](https://github.com/zeon-studio/open-hr-backend/pull/4) — please merge that PR first.

## Test plan

- [x] `/employees` with no archived employees: button is hidden, only active/pending rows visible
- [x] Seed an archived employee → "Archived Employee" button appears next to "Add Employee"
- [x] Click "Archived Employee" → navigates to `/employees-archived`, lists only archived rows
- [x] Search/pagination still works on both pages (each request includes the status filter)
- [x] "Back to Employees" returns to `/employees`

🤖 Generated with [Claude Code](https://claude.com/claude-code)