### PR TITLE
fix: only render vital sidebar items when their value is set

### DIFF
--- a/src/app/(protected)/employees/[employeeId]/page.tsx
+++ b/src/app/(protected)/employees/[employeeId]/page.tsx
@@ -288,63 +288,80 @@ export default function EmployeeSingle() {
             <div className="xl:max-w-[210px]">
               <h6 className="text-base font-semibold mb-4">Vitals</h6>
               <ul className="list-none space-y-4">
-                <li className="flex space-x-2 text-text-light">
-                  <Building className="size-4 stroke-current" />
-                  <div className="space-y-1.5">
-                    <span className="text-xs block font-semibold text-text-light">
-                      Present Address
-                    </span>
-                    <span className="text-xs block text-text-light">
-                      {data?.result.present_address}
-                    </span>
-                  </div>
-                </li>
+                {data?.result.present_address && (
+                  <li className="flex space-x-2 text-text-light">
+                    <Building className="size-4 stroke-current" />
+                    <div className="space-y-1.5">
+                      <span className="text-xs block font-semibold text-text-light">
+                        Present Address
+                      </span>
+                      <span className="text-xs block text-text-light">
+                        {data.result.present_address}
+                      </span>
+                    </div>
+                  </li>
+                )}
 
-                <li className="flex space-x-2 text-text-light">
-                  <Phone className="size-4 flex-none stroke-current" />
-                  <Link
-                    href={`tel:${data?.result.phone}`}
-                    className="flex space-x-2 text-xs"
-                  >
-                    {data?.result.phone}
-                  </Link>
-                </li>
+                {data?.result.phone && (
+                  <li className="flex space-x-2 text-text-light">
+                    <Phone className="size-4 flex-none stroke-current" />
+                    <Link
+                      href={`tel:${data.result.phone}`}
+                      className="flex space-x-2 text-xs"
+                    >
+                      {data.result.phone}
+                    </Link>
+                  </li>
+                )}
 
-                <li className="flex space-x-2 text-text-light">
-                  <Mail className="size-4 flex-none text-current" />
-                  <Link
-                    href={`mailto:${data?.result.work_email}`}
-                    className="flex space-x-2 text-xs"
-                  >
-                    {data?.result.work_email}
-                  </Link>
-                </li>
+                {data?.result.work_email && (
+                  <li className="flex space-x-2 text-text-light">
+                    <Mail className="size-4 flex-none text-current" />
+                    <Link
+                      href={`mailto:${data.result.work_email}`}
+                      className="flex space-x-2 text-xs"
+                    >
+                      {data.result.work_email}
+                    </Link>
+                  </li>
+                )}
 
-                <li className="flex space-x-2 text-text-light">
-                  <MessageCircle className="size-4 flex-none text-current" />
-                  <Link
-                    target="_blank"
-                    rel="noopener noreferrer nofollow"
-                    href={
-                      communication_platform_url + data?.result.communication_id
-                    }
-                    className="flex space-x-2 text-xs"
-                  >
-                    {communication_platform}
-                  </Link>
-                </li>
+                {communication_platform_url &&
+                  communication_platform &&
+                  data?.result.communication_id && (
+                    <li className="flex space-x-2 text-text-light">
+                      <MessageCircle className="size-4 flex-none text-current" />
+                      <Link
+                        target="_blank"
+                        rel="noopener noreferrer nofollow"
+                        href={
+                          communication_platform_url +
+                          data.result.communication_id
+                        }
+                        className="flex space-x-2 text-xs"
+                      >
+                        {communication_platform}
+                      </Link>
+                    </li>
+                  )}
 
-                <li className="flex space-x-2 text-text-light">
-                  <UserRoundCog className="size-4 stroke-current" />
-                  <div className="space-y-1.5">
-                    <span className="text-xs block font-semibold capitalize">
-                      {data?.result?.designation}
-                    </span>
-                    <span className="text-xs block capitalize">
-                      {jobData?.result?.job_type?.replace("_", " ")}
-                    </span>
-                  </div>
-                </li>
+                {(data?.result?.designation || jobData?.result?.job_type) && (
+                  <li className="flex space-x-2 text-text-light">
+                    <UserRoundCog className="size-4 stroke-current" />
+                    <div className="space-y-1.5">
+                      {data?.result?.designation && (
+                        <span className="text-xs block font-semibold capitalize">
+                          {data.result.designation}
+                        </span>
+                      )}
+                      {jobData?.result?.job_type && (
+                        <span className="text-xs block capitalize">
+                          {jobData.result.job_type.replace("_", " ")}
+                        </span>
+                      )}
+                    </div>
+                  </li>
+                )}
 
                 <li className="flex space-x-2 text-text-light">
                   <Hash className="size-4 stroke-current" />


### PR DESCRIPTION
## Summary

The vitals sidebar on `/employees/[id]` rendered every list item unconditionally, leaving lonely icons for any field the employee hadn't filled out — a telephone icon with no number, a mail icon with no address, a building icon with no text, a briefcase icon with no designation, and a Discord/Slack link to `https://discord.com/channels/@me/undefined` when no handle was set.

The Discord case additionally caused a **recoverable hydration mismatch**:

> Hydration failed because the server rendered text didn't match the client...

The diff React reports:

```diff
- href="undefined"
+ href="https://discord.com/channels/@me/<id>"

-
+ Discord
```

`communication_platform` and `communication_platform_url` come from the Redux setting-slice, which is populated by an effect in the protected layout. During SSR the slice is empty so the link renders as `<a href="undefined"></a>`. By the time React rehydrates on the client, the slice is populated and the link renders with real values. React detects the mismatch and regenerates the tree.

## What this PR does

Gates each `<li>` on the value(s) it displays:

- Present Address
- Phone
- Work Email
- Communication platform (Discord/Slack/etc.)
- Designation / job-type pair (each text line is also independently gated)

Employee Id stays unconditional — it's the lookup key and always present.

## Test plan

- [x] Open an employee profile with a sparse record — only populated vitals show; no orphan icons
- [x] Profile with a `communication_id` — Discord link appears and works
- [x] Profile without one — the entire row is hidden (no broken link, no hydration warning)
- [x] No "Hydration failed" overlay in the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)