### PR TITLE
style: increase vertical gap between personal-detail blocks

### DIFF
--- a/src/app/(protected)/employees/[employeeId]/_components/personal-form.tsx
+++ b/src/app/(protected)/employees/[employeeId]/_components/personal-form.tsx
@@ -49,7 +49,7 @@ export default function PersonalForm({
             e.preventDefault();
             onSubmit(data);
           }}
-          className="row gap-y-4"
+          className="row gap-y-6"
         >
           <div className="lg:col-6">
             <Label>Full Name:</Label>


### PR DESCRIPTION
## Summary

The two-column Personal Details form uses `gap-y-4` (16px) between rows. After labels gained leading icons (#12) and empty fields render as plain "Not provided" text (#10) the rows feel cramped — there's not enough whitespace separating one field from the next.

Bump to `gap-y-6` (24px). Single-line CSS change, no markup or behavior changes.

## Test plan

- [x] Personal Details renders with extra vertical breathing room between blocks
- [x] Layout still wraps correctly at lg/md/sm breakpoints
- [x] Edit mode also benefits from the gap (longer inputs no longer feel stacked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)