### PR TITLE
fix: hide social-link icons when their URL is empty

### DIFF
--- a/src/app/(protected)/employees/[employeeId]/page.tsx
+++ b/src/app/(protected)/employees/[employeeId]/page.tsx
@@ -390,40 +390,50 @@ export default function EmployeeSingle() {
               </div>
             )}
 
-            <div>
-              <h6 className="text-base font-semibold mb-4 text-text-dark">
-                Social
-              </h6>
-              <ul className="flex space-x-2">
-                <li>
-                  <Link
-                    target="_blank"
-                    rel="noopener noreferrer nofollow"
-                    href={data?.result.linkedin ?? ""}
-                  >
-                    <Linkedin className="size-7" />
-                  </Link>
-                </li>
-                <li className="flex items-center justify-center">
-                  <Link
-                    target="_blank"
-                    rel="noopener noreferrer nofollow"
-                    href={data?.result.twitter ?? ""}
-                  >
-                    <Twitter className="size-7" />
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    target="_blank"
-                    rel="noopener noreferrer nofollow"
-                    href={data?.result.facebook ?? ""}
-                  >
-                    <Facebook className="size-7" />
-                  </Link>
-                </li>
-              </ul>
-            </div>
+            {(data?.result.linkedin ||
+              data?.result.twitter ||
+              data?.result.facebook) && (
+              <div>
+                <h6 className="text-base font-semibold mb-4 text-text-dark">
+                  Social
+                </h6>
+                <ul className="flex space-x-2">
+                  {data?.result.linkedin && (
+                    <li>
+                      <Link
+                        target="_blank"
+                        rel="noopener noreferrer nofollow"
+                        href={data.result.linkedin}
+                      >
+                        <Linkedin className="size-7" />
+                      </Link>
+                    </li>
+                  )}
+                  {data?.result.twitter && (
+                    <li className="flex items-center justify-center">
+                      <Link
+                        target="_blank"
+                        rel="noopener noreferrer nofollow"
+                        href={data.result.twitter}
+                      >
+                        <Twitter className="size-7" />
+                      </Link>
+                    </li>
+                  )}
+                  {data?.result.facebook && (
+                    <li>
+                      <Link
+                        target="_blank"
+                        rel="noopener noreferrer nofollow"
+                        href={data.result.facebook}
+                      >
+                        <Facebook className="size-7" />
+                      </Link>
+                    </li>
+                  )}
+                </ul>
+              </div>
+            )}
           </div>
           <div className="xl:pl-6 flex-1">
             {tabs.map((tab, index) => (


### PR DESCRIPTION
## Summary

The Social section on `/employees/[id]` rendered all three icons (LinkedIn / Twitter / Facebook) unconditionally:

```tsx
<Link href={data?.result.linkedin ?? ""}>
  <Linkedin className="size-7" />
</Link>
```

When the employee hasn't filled in a profile URL the link points at `""` (or the current page), so a user sees a clickable icon that does nothing. The "Social" heading is also shown even when the employee has none of the three configured.

This PR gates each icon on its own URL value, and hides the heading and `<ul>` entirely when all three are empty.

## Test plan

- [x] Profile with no social links — Social section is fully hidden
- [x] Profile with one link (e.g. only LinkedIn) — only that icon shows
- [x] Profile with all three — same as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)