### PR TITLE
feat: profile completion score on employee profile

### DIFF
--- a/src/app/(protected)/employees/[employeeId]/page.tsx
+++ b/src/app/(protected)/employees/[employeeId]/page.tsx
@@ -3,6 +3,7 @@
 import Avatar from "@/components/avatar";
 import { Facebook, Linkedin, Twitter } from "@/components/icons";
 import { getDuration } from "@/lib/date-converter";
+import { profileCompletion } from "@/lib/profile-completion";
 import { cn } from "@/lib/shadcn";
 import { useGetEmployeeQuery } from "@/redux/features/employeeApiSlice/employeeSlice";
 import { useGetEmployeeJobQuery } from "@/redux/features/employeeJobApiSlice/employeeJobSlice";
@@ -176,6 +177,8 @@ export default function EmployeeSingle() {
 
   const formattedDuration = `${employmentDuration.years || 0}y - ${employmentDuration.months || 0}m - ${employmentDuration.days || 0}d`;
 
+  const completion = profileCompletion(data?.result);
+
   const handleMouseDown = (tab: (typeof tabs)[0]) => {
     const urlSearchParams = new URLSearchParams(searchParams?.toString());
     urlSearchParams.set("tab", tab.value);
@@ -285,6 +288,48 @@ export default function EmployeeSingle() {
 
         <div className="gap-5 px-4 pb-4 mt-6 lg:mt-8 xl:mt-16 flex">
           <div className="space-y-5 xl:basis-[210px] hidden xl:block xl:pl-8">
+            <div
+              className="xl:max-w-[210px]"
+              aria-label={`Profile ${completion.percent}% complete`}
+            >
+              <div className="flex items-center justify-between mb-1.5">
+                <span className="text-xs font-semibold text-text-dark">
+                  Profile completion
+                </span>
+                <span className="text-xs font-semibold text-text-dark">
+                  {completion.percent}%
+                </span>
+              </div>
+              <div className="h-1.5 w-full rounded-full bg-light overflow-hidden">
+                <div
+                  className={cn(
+                    "h-full rounded-full transition-all",
+                    completion.percent >= 80
+                      ? "bg-success"
+                      : completion.percent >= 50
+                        ? "bg-warning"
+                        : "bg-destructive"
+                  )}
+                  style={{ width: `${completion.percent}%` }}
+                />
+              </div>
+              <p className="text-[10px] text-text-light mt-1">
+                {completion.filled} of {completion.total} fields filled
+              </p>
+              {completion.missing.length > 0 && (
+                <details className="mt-2 text-[11px] text-text-light group">
+                  <summary className="cursor-pointer select-none hover:text-text-dark transition-colors">
+                    View {completion.missing.length} missing field
+                    {completion.missing.length === 1 ? "" : "s"}
+                  </summary>
+                  <ul className="mt-1.5 pl-4 list-disc space-y-0.5">
+                    {completion.missing.map((label) => (
+                      <li key={label}>{label}</li>
+                    ))}
+                  </ul>
+                </details>
+              )}
+            </div>
             <div className="xl:max-w-[210px]">
               <h6 className="text-base font-semibold mb-4">Vitals</h6>
               <ul className="list-none space-y-4">

--- a/src/lib/profile-completion.ts
+++ b/src/lib/profile-completion.ts
@@ -1,0 +1,55 @@
+import type { TEmployee } from "@/redux/features/employeeApiSlice/employeeType";
+
+// Fields that count toward the profile completion percentage. Equal weight per field.
+// The label is shown to the user when listing missing fields.
+const SCORED_FIELDS: { key: keyof TEmployee; label: string }[] = [
+  { key: "name", label: "Full Name" },
+  { key: "image", label: "Profile Photo" },
+  { key: "phone", label: "Mobile Phone" },
+  { key: "work_email", label: "Work Email" },
+  { key: "personal_email", label: "Personal Email" },
+  { key: "dob", label: "Date of Birth" },
+  { key: "gender", label: "Gender" },
+  { key: "present_address", label: "Present Address" },
+  { key: "permanent_address", label: "Permanent Address" },
+  { key: "blood_group", label: "Blood Group" },
+  { key: "marital_status", label: "Marital Status" },
+  { key: "nid", label: "NID" },
+  { key: "designation", label: "Designation" },
+  { key: "department", label: "Department" },
+];
+
+const isFilled = (value: unknown): boolean => {
+  if (value === null || value === undefined) return false;
+  if (typeof value === "string") return value.trim().length > 0;
+  return true;
+};
+
+export function profileCompletion(employee?: Partial<TEmployee> | null): {
+  filled: number;
+  total: number;
+  percent: number;
+  missing: string[];
+} {
+  const total = SCORED_FIELDS.length;
+  if (!employee) {
+    return {
+      filled: 0,
+      total,
+      percent: 0,
+      missing: SCORED_FIELDS.map((f) => f.label),
+    };
+  }
+  const missing: string[] = [];
+  let filled = 0;
+  for (const { key, label } of SCORED_FIELDS) {
+    if (isFilled(employee[key])) filled += 1;
+    else missing.push(label);
+  }
+  return {
+    filled,
+    total,
+    percent: Math.round((filled / total) * 100),
+    missing,
+  };
+}


### PR DESCRIPTION
## Summary

Adds a small "Profile completion" indicator at the top of the employee profile sidebar so admins and employees can see at a glance how much of the profile is filled out — **and which specific fields are still missing**.

**What it looks like**

```
Profile completion          50%
█████████░░░░░░░░░░
7 of 14 fields filled
▸ View 7 missing fields           ← native <details>, expands to show:
   • Profile Photo
   • Date of Birth
   • Gender
   • Permanent Address
   • Blood Group
   • Marital Status
   • NID
```

The bar is colour-coded against existing theme tokens — `bg-success` (green) at ≥80%, `bg-warning` (yellow) at ≥50%, `bg-destructive` (red) below.

## Implementation

- New helper [src/lib/profile-completion.ts](src/lib/profile-completion.ts) returns `{ filled, total, percent, missing }` from a `TEmployee`. Equal weight per field; counts a field "filled" when the value is non-empty (trims strings).
- Inline progress bar — no new UI primitive added.
- Native `<details>` disclosure for the missing-fields list — keeps the sidebar compact by default but makes the gaps actionable.

**Fields scored** (14 total, all on the employee record itself, equal weight):

`Full Name`, `Profile Photo`, `Mobile Phone`, `Work Email`, `Personal Email`, `Date of Birth`, `Gender`, `Present Address`, `Permanent Address`, `Blood Group`, `Marital Status`, `NID`, `Designation`, `Department`

Other modules (job, payroll, documents, achievements) intentionally aren't counted in this first cut. Extending coverage is a matter of adding to `SCORED_FIELDS` (or expanding the helper to take more inputs).

## Test plan

- [x] New employee with only name/email/role set → low percent, red bar, list of missing fields
- [x] Half-filled profile → ~50%, yellow bar
- [x] Fully filled profile → 100%, green bar, no disclosure (nothing missing)
- [x] Indicator only shows in xl breakpoint (matches existing sidebar visibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)