### PR TITLE
fix: hide Join Date section when no date is available

### DIFF
--- a/src/app/(protected)/employees/[employeeId]/page.tsx
+++ b/src/app/(protected)/employees/[employeeId]/page.tsx
@@ -359,23 +359,23 @@ export default function EmployeeSingle() {
               <Separator className="my-5" />
             </div>
 
-            {!jobData?.result?.resignation_date && (
-              <div>
-                <h6 className="text-base font-semibold mb-4 text-text-dark">
-                  Join Date
-                </h6>
-                <ul className="list-none space-y-4">
-                  {(jobData?.result?.permanent_date ||
-                    jobData?.result?.joining_date) && (
+            {!jobData?.result?.resignation_date &&
+              (jobData?.result?.permanent_date ||
+                jobData?.result?.joining_date) && (
+                <div>
+                  <h6 className="text-base font-semibold mb-4 text-text-dark">
+                    Join Date
+                  </h6>
+                  <ul className="list-none space-y-4">
                     <li className="flex space-x-2 text-text-light">
                       <Calendar className="size-4 stroke-current" />
                       <div className="space-y-1.5">
                         <span className="text-xs block font-semibold">
                           {format(
                             new Date(
-                              jobData?.result?.permanent_date
-                                ? jobData?.result?.permanent_date
-                                : jobData?.result?.joining_date
+                              jobData.result.permanent_date
+                                ? jobData.result.permanent_date
+                                : jobData.result.joining_date
                             ),
                             "MMM d, yyyy"
                           )}
@@ -385,10 +385,9 @@ export default function EmployeeSingle() {
                         </span>
                       </div>
                     </li>
-                  )}
-                </ul>
-              </div>
-            )}
+                  </ul>
+                </div>
+              )}
 
             <div>
               <h6 className="text-base font-semibold mb-4 text-text-dark">


### PR DESCRIPTION
## Summary

The "Join Date" heading on the employee profile sidebar was gated only on the absence of `resignation_date`, so it rendered for **every** non-resigned employee. The actual date row inside it is correctly gated on having `permanent_date` or `joining_date`, so when neither is set you see the heading with an empty list below it:

```
Join Date
(empty)
```

This PR moves the date check up to the wrapping `<div>` so the heading and list hide together when neither date is set.

## Test plan

- [x] Employee with `joining_date` only → "Join Date" heading + formatted date + duration shown
- [x] Employee with no dates → entire "Join Date" section hidden
- [x] Resigned employee → still hidden (existing behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)