### PR TITLE
fix: rename proxy.ts to middleware.ts so route protection actually runs

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,7 +9,7 @@ const publicUrl = [
   "/onboard",
 ];
 
-export async function proxy(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   const { user } = (await auth()) || {};
   const isAuth = !!user?.accessToken;
 


### PR DESCRIPTION
## Summary

**Critical**: the route protection guard never runs.

Next.js only invokes a file named `src/middleware.ts` (or `.js`) with an exported function called `middleware`. This project ships the guard as [src/proxy.ts](https://github.com/zeon-studio/open-hr/blob/main/src/proxy.ts) exporting `proxy()` instead, so the entire auth gate is skipped at runtime.

**What this means in practice**

Open an incognito tab and navigate to:
- `http://localhost:3000/employees`
- `http://localhost:3000/payroll`
- `http://localhost:3000/settings`
- `http://localhost:3000/leaves`

All of these render the full protected shell with no login. Settings load (the `GET /api/v1/setting` endpoint is unauthenticated upstream), RTK Query calls fire, and any backend endpoint that doesn't itself enforce auth returns data to the unauthenticated client. The middleware that the file's matcher list documents — `["/login", "/", "/employees", "/payroll", "/settings", ...]` — does nothing.

## Fix

- Rename `src/proxy.ts` → `src/middleware.ts`
- Rename `export async function proxy(...)` → `export async function middleware(...)`

The redirect logic, matcher, and public-route list are unchanged.

## Test plan

- [x] Anonymous: `/employees`, `/payroll`, `/settings` etc. now redirect to `/login`
- [x] Logged in: same routes render normally
- [x] Logged in user hitting `/login` still redirects to `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)