### PR TITLE
fix: forward Google ID token to backend oauth-login

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -104,9 +104,16 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         return !!user;
       }
 
-      const res = await Axios.post("/authentication/oauth-login", {
-        email: user.email,
-      });
+      // SECURITY: Forward the Google-issued ID token to the backend so it
+      // can verify the signature against Google's public keys. Trusting
+      // user.email here would let anyone POST any email to /oauth-login
+      // and log in as that user.
+      const idToken = account?.id_token;
+      if (!idToken) {
+        return false;
+      }
+
+      const res = await Axios.post("/authentication/oauth-login", { idToken });
 
       if (res.status === 200) {
         user.id = res.data.result.userId;


### PR DESCRIPTION
## Summary

Companion to backend PR [zeon-studio/open-hr-backend#6](https://github.com/zeon-studio/open-hr-backend/pull/6).

NextAuth's Google provider populates `account.id_token` with the JWT issued by Google for the user. Today's `signIn` callback discards that token and instead forwards `user.email` — an unverified plaintext value — to `/authentication/oauth-login`. The backend uses that email to issue a bearer JWT with no proof of ownership, which means anyone with network access to the backend can call `/oauth-login` directly and log in as any employee.

Forward the ID token instead so the backend can verify it against Google's public keys and pin audience to its own `GOOGLE_CLIENT_ID`.

## Changes

- `src/auth.ts` `signIn` callback now sends `{ idToken: account.id_token }` instead of `{ email: user.email }`
- Refuses sign-in if no `id_token` is present (defense in depth — should not occur with the standard Google provider, but guards against misconfiguration of `authorization.params`)

## Required for testing

Both PRs need to land together. With only the backend change merged, sign-in via Google will break (backend rejects the email-only payload). With only the frontend change merged, the backend ignores the `idToken` field and still trusts the (now-empty) email.

## Test plan

- [x] Set `GOOGLE_CLIENT_ID` in backend `.env` to match `GOOGLE_CLIENT_ID` in frontend `.env`
- [x] Click "Sign in with Google" → completes OAuth dance → backend receives valid ID token → JWT issued
- [x] Direct `curl` against `/oauth-login` with bare email is now rejected (backend PR test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)