### PR TITLE
perf: optimize lucide/date-fns imports + cache upcoming-events query

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -28,6 +28,13 @@ const nextConfig = {
     ],
   },
   reactStrictMode: true,
+  experimental: {
+    // Tree-shake heavy icon / utility libs imported across the app so each
+    // file pulls only the symbols it uses. lucide-react alone is imported
+    // from 73 source files; without this Turbopack rebuilds large icon
+    // chunks on every dev edit.
+    optimizePackageImports: ["lucide-react", "date-fns"],
+  },
 };
 
 module.exports = nextConfig;

--- a/src/redux/features/calendarApiSlice/calendarSlice.ts
+++ b/src/redux/features/calendarApiSlice/calendarSlice.ts
@@ -31,6 +31,7 @@ export const calendarApi = calendarApiWithTag.injectEndpoints({
         method: "GET",
       }),
       providesTags: ["calendars"],
+      keepUnusedDataFor: 30 * 60,
     }),
 
     addCalendar: builder.mutation<TCalendarState, TCalendar>({


### PR DESCRIPTION
## Summary

Two zero-risk dev-performance wins surfaced by a performance audit.

### 1. `experimental.optimizePackageImports`

`lucide-react` is imported from **73** source files; `date-fns` from many more. Without this Next.js option, every file pulls a sizeable chunk and Turbopack rebuilds the lot on each dev edit. The Next.js docs call out this exact case as the primary reason to enable the option.

### 2. `keepUnusedDataFor` on the upcoming-events endpoint

`getUpcomingHolidaysAndEvents` was the only calendar endpoint without `keepUnusedDataFor`; it fell back to the 60-second default while its siblings stay warm for 30 minutes. The dashboard mounts both `<UpcomingHolidays>` and `<UpcomingEvents>`, so this query refires whenever the user navigates away and back after a minute.

## Test plan

- [x] `next dev` compiles cleanly
- [x] Dashboard loads, upcoming events/holidays cards still populate
- [x] Subsequent dashboard navigation no longer refires the upcoming endpoint within the cache window

🤖 Generated with [Claude Code](https://claude.com/claude-code)