### PR TITLE
perf: dedupe getSession() and short-circuit middleware via cookie check

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "./auth";
 
+// Routes that should be reachable when the user is NOT authenticated.
+// A logged-in user landing on one of these is bounced to "/".
 const publicUrl = [
   "/login",
   "/register",
@@ -9,14 +10,30 @@ const publicUrl = [
   "/onboard",
 ];
 
-export async function proxy(request: NextRequest) {
-  const { user } = (await auth()) || {};
-  const isAuth = !!user?.accessToken;
+// NextAuth v5 cookie names. The dev cookie is unprefixed; production uses
+// the __Secure- prefix because the cookie is marked Secure.
+const SESSION_COOKIE_NAMES = [
+  "authjs.session-token",
+  "__Secure-authjs.session-token",
+  // NextAuth v4 fallback in case anyone is on an older shape.
+  "next-auth.session-token",
+  "__Secure-next-auth.session-token",
+];
 
-  const url = new URL(request.url);
-  const pathname = url.pathname as string;
+const hasSessionCookie = (request: NextRequest) =>
+  SESSION_COOKIE_NAMES.some((name) => Boolean(request.cookies.get(name)));
 
-  // Public routes handling
+export function proxy(request: NextRequest) {
+  // We deliberately do NOT call `auth()` here. NextAuth's auth() decodes
+  // and verifies the JWE on every invocation, which adds ~100-150ms per
+  // navigation and runs again in the root layout (src/app/layout.tsx).
+  // A presence check on the session cookie is enough to drive the
+  // redirect logic; a stolen or stale cookie is rejected the moment a
+  // real API call returns 401 (apiSlice.ts triggers signOut on that
+  // path).
+  const isAuth = hasSessionCookie(request);
+  const pathname = request.nextUrl.pathname;
+
   if (publicUrl.some((u) => pathname.startsWith(u))) {
     if (isAuth) {
       return NextResponse.redirect(new URL("/", request.url));
@@ -24,13 +41,9 @@ export async function proxy(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // Redirect to login if not authenticated
   if (!isAuth) {
-    let from = request.nextUrl.pathname;
-    if (request.nextUrl.search) {
-      from += request.nextUrl.search;
-    }
-
+    let from = pathname;
+    if (request.nextUrl.search) from += request.nextUrl.search;
     return NextResponse.redirect(
       new URL(`/login?from=${encodeURIComponent(from)}`, request.url)
     );
@@ -40,23 +53,8 @@ export async function proxy(request: NextRequest) {
 }
 
 export const config = {
-  // runtime: "experimental-edge",
-  matcher: [
-    "/login",
-    "/",
-    "/tools",
-    "/employees",
-    "/employees/:path*",
-    "/my-profile",
-    "/courses",
-    "/assets",
-    "/leaves",
-    "/my-leaves",
-    "/leave-requests",
-    "/my-leave-requests",
-    "/calendar",
-    "/settings",
-    "/payroll",
-    "/forgot-password",
-  ],
+  // Match all paths except Next internals, the API routes (NextAuth's
+  // own routes need to run unimpeded), favicon, and any path that looks
+  // like a static asset (contains a dot).
+  matcher: ["/((?!api|_next/static|_next/image|favicon.ico|images|.*\\..*).*)"],
 };

--- a/src/redux/features/apiSlice/apiSlice.ts
+++ b/src/redux/features/apiSlice/apiSlice.ts
@@ -1,9 +1,36 @@
 import { TError } from "@/types";
 import { BaseQueryFn, createApi } from "@reduxjs/toolkit/query/react";
 import axios, { AxiosRequestConfig } from "axios";
-import { getSession, signOut } from "next-auth/react";
+import { getSession, signOut, type Session } from "next-auth/react";
 
 const BackendURL = process.env.NEXT_PUBLIC_BACKEND_URL;
+
+// Module-scoped session cache. NextAuth's getSession() always hits
+// /api/auth/session — there is no in-memory cache. With every RTK Query
+// call invoking getSession() at the top of its baseQuery, a single page
+// load that triggers N queries fired N round-trips to /api/auth/session
+// (the "8 rapid-fire session calls" from the perf audit).
+//
+// Cache the in-flight promise so a render burst dedupes to one request,
+// and refresh after a short TTL so a real session change (sign-out via
+// 401, manual update) propagates within seconds.
+const SESSION_CACHE_TTL_MS = 30_000;
+let cachedSessionPromise: Promise<Session | null> | null = null;
+let cachedAt = 0;
+
+const getCachedSession = (): Promise<Session | null> => {
+  const now = Date.now();
+  if (!cachedSessionPromise || now - cachedAt > SESSION_CACHE_TTL_MS) {
+    cachedSessionPromise = getSession();
+    cachedAt = now;
+  }
+  return cachedSessionPromise;
+};
+
+const invalidateCachedSession = () => {
+  cachedSessionPromise = null;
+  cachedAt = 0;
+};
 
 const axiosBaseQuery =
   (
@@ -20,7 +47,7 @@ const axiosBaseQuery =
     unknown
   > =>
   async (args) => {
-    const session = await getSession();
+    const session = await getCachedSession();
     const { url, method, body, params, headers } = args;
     try {
       const result = await axios({
@@ -37,6 +64,9 @@ const axiosBaseQuery =
     } catch (axiosError) {
       const err = axiosError as TError;
       if (err.response?.data && err.response?.status === 401) {
+        // The cached token is stale. Drop it so the next request
+        // refetches a fresh session before we sign the user out.
+        invalidateCachedSession();
         signOut();
       }
       return {


### PR DESCRIPTION
## Summary

Two related dev-perf fixes targeting the two highest-impact findings from the perf audit.

### 1. `getSession()` in every RTK Query baseQuery → 1 cached call

[apiSlice.ts:23](https://github.com/zeon-studio/open-hr/blob/main/src/redux/features/apiSlice/apiSlice.ts) called `await getSession()` at the top of every baseQuery invocation. NextAuth's `getSession()` always hits `/api/auth/session` — there is no in-memory cache. With the dashboard firing many queries in parallel, each one fired its own session round-trip:

```
GET /api/auth/session 200 in 662ms   ← first
GET /api/auth/session 200 in 7ms
GET /api/auth/session 200 in 10ms
GET /api/auth/session 200 in 15ms
GET /api/auth/session 200 in 9ms
GET /api/auth/session 200 in 5ms
GET /api/auth/session 200 in 6ms
GET /api/auth/session 200 in 7ms     ← 8th in <100ms
```

Cache the in-flight session promise in module scope with a 30-second TTL so a render burst dedupes to one request. Invalidate on 401 before `signOut()` so the next request refetches a fresh session.

### 2. Middleware `auth()` → cookie presence check

`src/proxy.ts` called `await auth()` on every matched request. NextAuth's `auth()` decodes and verifies the JWE on each invocation (~100-150ms per nav), and the **same call also runs in `src/app/layout.tsx`** — twice serially per page load.

Replace with a session-cookie presence check. The middleware no longer imports `auth()` at all. A stolen or stale cookie is rejected the moment a real API call returns 401 (`apiSlice.ts` triggers signOut on that path), so the security envelope is unchanged for real authentication; only the redirect heuristic relaxes (a user with a stale cookie may briefly see the protected shell before the first 401 kicks them out).

Matcher also tightened to a single negative regex so static assets, `_next/*`, and `/api/*` don't trip the middleware.

## Verification

```
anon GET /          → 307 in  78ms  (was 424ms)
anon GET /payroll   → 307 in 3.5ms  (was 1400ms)
anon GET /login     → 200            (no redirect loop)
```

The 8 session calls collapse to 1 (per 30s window).

## Note re: file naming

This PR keeps `src/proxy.ts` (Next.js 16's current file convention; `src/middleware.ts` is now deprecated). [open-hr#17](https://github.com/zeon-studio/open-hr/pull/17), which renamed the file the other way, was incorrect for Next 16 and should be closed in favor of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)