### PR TITLE
perf: lazy-mount dialog content + dedupe localStorage writes

### DIFF
--- a/src/app/(protected)/assets/page.tsx
+++ b/src/app/(protected)/assets/page.tsx
@@ -58,7 +58,7 @@ const Asset = () => {
           <DialogTrigger asChild>
             <Button className="ml-auto">Add New Asset</Button>
           </DialogTrigger>
-          <AssetInsert onDialogChange={onDialogChange} />
+          {isDialogOpen && <AssetInsert onDialogChange={onDialogChange} />}
         </Dialog>
       </div>
 

--- a/src/app/(protected)/calendar/page.tsx
+++ b/src/app/(protected)/calendar/page.tsx
@@ -111,7 +111,9 @@ const CalendarPage = () => {
                     Add Calendar Year
                   </Button>
                 </DialogTrigger>
-                <CalendarInsert onDialogChange={onDialogChange} />
+                {isDialogOpen && (
+                  <CalendarInsert onDialogChange={onDialogChange} />
+                )}
               </Dialog>
               <CalendarInsertSheet />
             </div>

--- a/src/app/(protected)/courses/page.tsx
+++ b/src/app/(protected)/courses/page.tsx
@@ -58,7 +58,7 @@ const Course = () => {
           <DialogTrigger asChild>
             <Button className="ml-auto">Add New Platform</Button>
           </DialogTrigger>
-          <CourseInsert onDialogChange={onDialogChange} />
+          {isDialogOpen && <CourseInsert onDialogChange={onDialogChange} />}
         </Dialog>
       </div>
 

--- a/src/app/(protected)/employees/page.tsx
+++ b/src/app/(protected)/employees/page.tsx
@@ -53,7 +53,7 @@ export default function Employees() {
           <DialogTrigger asChild>
             <Button className="ml-auto">Add Employee</Button>
           </DialogTrigger>
-          <EmployeeInsert onDialogChange={onDialogChange} />
+          {isDialogOpen && <EmployeeInsert onDialogChange={onDialogChange} />}
         </Dialog>
       </div>
 

--- a/src/app/(protected)/my-leave-requests/page.tsx
+++ b/src/app/(protected)/my-leave-requests/page.tsx
@@ -63,7 +63,9 @@ const LeaveRequest = () => {
             <DialogTrigger asChild>
               <Button className="ml-auto">Request Leave</Button>
             </DialogTrigger>
-            <LeaveRequestInsert onDialogChange={onDialogChange} />
+            {isDialogOpen && (
+              <LeaveRequestInsert onDialogChange={onDialogChange} />
+            )}
           </Dialog>
         )}
       </div>

--- a/src/app/(protected)/payroll/page.tsx
+++ b/src/app/(protected)/payroll/page.tsx
@@ -57,7 +57,7 @@ const Payroll = () => {
           <DialogTrigger asChild>
             <Button className="ml-auto">Add Salary</Button>
           </DialogTrigger>
-          <PayrollInsert onDialogChange={onDialogChange} />
+          {isDialogOpen && <PayrollInsert onDialogChange={onDialogChange} />}
         </Dialog>
       </div>
 

--- a/src/app/(protected)/tools/page.tsx
+++ b/src/app/(protected)/tools/page.tsx
@@ -58,7 +58,7 @@ const Tool = () => {
           <DialogTrigger asChild>
             <Button className="ml-auto">Add New Platform</Button>
           </DialogTrigger>
-          <ToolInsert onDialogChange={onDialogChange} />
+          {isDialogOpen && <ToolInsert onDialogChange={onDialogChange} />}
         </Dialog>
       </div>
 

--- a/src/hooks/useLocalCacheHook.ts
+++ b/src/hooks/useLocalCacheHook.ts
@@ -1,24 +1,38 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 import { useEffect, useState } from "react";
+
 interface Data<T> {
   data: T[];
 }
 
+// Hydrate from localStorage on mount, then mirror RTK Query data back into
+// it so a page reload has cached data while the network call is in flight.
+//
+// Performance note: callers pass `{ data: result }` constructed as an inline
+// object literal on every render, so depending on `data` (the wrapper) ran
+// the write effect every render. Depend on `data.data` (the inner array)
+// instead — RTK Query keeps the same array reference across renders for
+// cached data, so the effect now fires only when the data actually changes.
 const useLocalCacheHook = <T>(data: Data<T>, name: string) => {
   const [localData, setLocalData] = useState<T[]>([]);
 
   useEffect(() => {
-    const storedData = localStorage.getItem(name);
-    if (storedData) {
-      setLocalData(JSON.parse(storedData));
+    try {
+      const storedData = localStorage.getItem(name);
+      if (storedData) setLocalData(JSON.parse(storedData));
+    } catch {
+      // private mode / quota / corrupt JSON — ignore
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
-    if (data.data?.length > 0) {
+    if (!data.data?.length) return;
+    try {
       localStorage.setItem(name, JSON.stringify(data.data));
+    } catch {
+      // quota exceeded — keep going, in-memory copy is still good
     }
-  }, [data]);
+  }, [data.data, name]);
 
   return {
     localData: localData,

--- a/src/lib/employee-info.ts
+++ b/src/lib/employee-info.ts
@@ -1,7 +1,15 @@
 import { TEmployee } from "@/redux/features/employeeApiSlice/employeeType";
 import { store } from "@/redux/store";
 
-const getEmployeesData = () => {
+const STORAGE_KEY = "local-employees-basics";
+
+// Track the last `result` reference we synced to localStorage so we only
+// JSON.stringify and write when the underlying data actually changes.
+// Without this, every consumer call (often inside .map() loops on lists)
+// stringified and rewrote the entire roster — N writes per render.
+let lastWrittenRef: unknown = undefined;
+
+const getEmployeesData = (): Partial<TEmployee>[] => {
   const employees = store.getState().api.queries[
     "getEmployeesBasics(undefined)"
   ] as {
@@ -10,16 +18,31 @@ const getEmployeesData = () => {
     };
   };
 
-  const storedData = localStorage.getItem("local-employees-basics");
-  if (employees?.data?.result) {
-    localStorage.setItem(
-      "local-employees-basics",
-      JSON.stringify(employees.data.result)
-    );
-    return employees.data.result;
+  // localStorage is unavailable during SSR; return whatever the in-memory
+  // store has (empty array on first server pass).
+  if (typeof window === "undefined") {
+    return employees?.data?.result ?? [];
   }
 
-  return storedData ? JSON.parse(storedData) : [];
+  const result = employees?.data?.result;
+  if (result) {
+    if (result !== lastWrittenRef) {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(result));
+        lastWrittenRef = result;
+      } catch {
+        // quota exceeded or private mode — stay in memory
+      }
+    }
+    return result;
+  }
+
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored ? JSON.parse(stored) : [];
+  } catch {
+    return [];
+  }
 };
 
 export const employeeInfoById = (id: string) => {


### PR DESCRIPTION
## Summary

Three follow-up wins from the performance audit; all local cleanups with no behavior change for the user.

### 1. Lazy-mount insert dialog content

Insert dialogs on `/payroll`, `/employees`, `/tools`, `/courses`, `/assets`, `/calendar`, `/my-leave-requests` previously rendered `<XInsert />` as a permanent child of `<Dialog>`. Each `<XInsert>` mounts on every page visit and fires its own RTK Query calls (e.g. `PayrollInsert` fetches `/payroll/basics` + `/employee/basics`) **before** the user clicks "Add Salary" / "Add Employee" etc.

Wrap each with `{isDialogOpen && <XInsert ... />}` so the queries fire only when the dialog is actually opened.

### 2. `employee-info.ts` localStorage thrash

`getEmployeesData()` wrote the entire employees-basics roster to localStorage on every call. Consumers (`employeeInfoById`) call this inside `.map()` loops on list pages, so a roster of N rows produced **N JSON.stringify + setItem calls per render**.

Track the last-written reference in module scope and only write when the underlying RTK Query result reference changes. Also adds the SSR guard the audit flagged separately, **replacing the standalone fix in [open-hr#8](https://github.com/zeon-studio/open-hr/pull/8)** — please close that one in favor of this PR.

### 3. `useLocalCacheHook` dependency fix

The hook's write effect depended on the wrapper object `{data: result}` constructed inline by callers, so it fired every render. Depend on `data.data` (the inner array) instead — RTK Query keeps the same reference across renders for cached data, so the effect now fires only on real changes.

## Test plan

- [x] All affected pages still render
- [x] Clicking "Add X" opens the dialog with the form properly populated (queries now fire on open)
- [x] Editing an employee record still updates localStorage so a hard reload retains the cached roster

🤖 Generated with [Claude Code](https://claude.com/claude-code)